### PR TITLE
Add docker-compose.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@
 Show notes, slides, and samples from the CSharp with CSharpFritz show.  Jupyter notebooks are available in the [notebooks](notebooks) folder. Notebooks are built using [.NET Interactive](https://github.com/dotnet/interactive). 
 
 Recordings from the stream are available in the [CSharp with CSharpFritz playlist](https://www.youtube.com/playlist?list=PLdo4fOcmZ0oXv32dOd36UydQYLejKR61R) on the YouTube .NET channel.
+
+Start locally with docker-compose:
+```shell
+docker-compose up
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.7'
+services:
+    notebook:
+        build:
+            context: .
+        ports:
+          - "8888:8888"
+        volumes:
+          - ./notebooks/:/home/jovyan/notebooks/


### PR DESCRIPTION
Add a basic docker-compose.yml file to start the project locally with docker-compose
- Uses the Dockerfile without changes.
- Forward port 8888
- add notebooks folder as volume