### PR TITLE
Add dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+	"name": "C# with CSharpFritz",
+	"dockerComposeFile": [
+		"../docker-compose.yml",
+	],
+	"shutdownAction": "stopCompose",
+	"service": "notebook",
+	"workspaceFolder": "/home/jovyan/notebooks/",
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+	"extensions": [
+		"ms-dotnettools.csharp",
+		"donjayamanne.jupyter",
+		"yzhang.markdown-all-in-one",
+		"ms-dotnettools.dotnet-interactive-vscode"
+	]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,6 +13,10 @@
 		"ms-dotnettools.csharp",
 		"donjayamanne.jupyter",
 		"yzhang.markdown-all-in-one",
-		"ms-dotnettools.dotnet-interactive-vscode"
-	]
+		"ms-dotnettools.dotnet-interactive-vscode",
+		"streetsidesoftware.code-spell-checker"
+	],
+	// "mounts": [
+	// 	"source=${localWorkspaceFolder}/notebooks,target=/home/jovyan/notebooks/,type=bind,consistency=cached"
+	// ]
 }


### PR DESCRIPTION
The goal of this is to provide a first-class experience for developers who want to run notebooks locally.

As a developer, I might start working with this example 

1. Run command pallet and run _"Clone Repository in Container Volume"_  (you need to have `ms-vscode-remote.vscode-remote-extensionpack` installed)
2. Select a _csharpfritz/csharp_with_csharpfritz/_ repo
![image](https://user-images.githubusercontent.com/8037439/95355318-15629700-08ce-11eb-93e7-9f4f86bab150.png)
3. After successful installation, a user will see something like this
![image](https://user-images.githubusercontent.com/8037439/95355467-4642cc00-08ce-11eb-8b19-f53e838f73c7.png)
4. Port 8888 is already exposed and can be consumed to open notebooks
5. Inside vscode, you can run `jupyter notebook list` to explore endpoint with hosted notebooks. Links are clickable and I like it! 
![image](https://user-images.githubusercontent.com/8037439/95355983-d84ad480-08ce-11eb-8725-e35224bc97e4.png)
![image](https://user-images.githubusercontent.com/8037439/95357729-e994e080-08d0-11eb-9364-53caa827c345.png)

###  Caveats

* Dev containers are still under active development. 
* I've included the extension (`ms-dotnettools.vscode-dotnet-runtime`) to edit and run jupyter notebooks based on C# engine. It requires vscode-insiders.

Closes: #44 